### PR TITLE
Fix iOS Link Error

### DIFF
--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -2,6 +2,8 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>FLTEnableImpeller</key>
+	<false />
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/ffigen_ailia_audio.yaml
+++ b/ffigen_ailia_audio.yaml
@@ -1,0 +1,8 @@
+﻿name: 'ailiaAudioFFI'
+description: 'Written for the FFI article'
+output: 'lib/ffi/ailia_audio.dart'
+headers:
+  entry-points:
+    - 'native/ailia_audio.h'
+llvm-path:
+  - '/usr/local/opt/llvm@15'

--- a/ios/Classes/AiliaAudioPluginPreventStrip.c
+++ b/ios/Classes/AiliaAudioPluginPreventStrip.c
@@ -1,0 +1,13 @@
+//
+//  AiliaAudioPluginPreventStrip.c
+//
+//  Created by Kazuki Kyakuno on 2023/07/31.
+//
+
+// Dummy link to keep libailia_audio.a from being deleted
+
+extern int ailiaAudioLog1p(void* dst, const void* src, int src_n);
+
+void test(void){
+    ailiaAudioLog1p(0, 0, 0);
+}

--- a/ios/ailia_audio.podspec
+++ b/ios/ailia_audio.podspec
@@ -17,6 +17,7 @@ A new Flutter plugin project.
   s.vendored_libraries = '*.a'
   s.dependency 'Flutter'
   s.platform = :ios, '11.0'
+  s.libraries = "ailia_audio"
 
   # Flutter.framework does not contain a i386 slice.
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }


### PR DESCRIPTION
iOSでシンボルがStripされてリンクエラーもしくはシンボルが見つからないエラーになる問題を修正。

- AiliaAudioPluginPreventStrip.cで明示的に.aの中の関数を呼び出してStripを抑制
- podspecにlibraries属性を追加
- exampleのFlutterでFLTEnableImpellerのエラーになる問題を修正